### PR TITLE
Develop hardened image

### DIFF
--- a/src/templates/cromwell/cromwell-resources.template.yaml
+++ b/src/templates/cromwell/cromwell-resources.template.yaml
@@ -115,9 +115,10 @@ Parameters:
   LatestAmazonLinuxAMI:
     Description: The latest Amazon Linux AMI
     Type: AWS::SSM::Parameter::Value<AWS::EC2::Image::Id>
-    Default: /aws/service/ami-amazon-linux-latest/amzn2-ami-hvm-x86_64-gp2
+    Default: /cromwell/ami/amazon-linux2
     AllowedValues:
       - /aws/service/ami-amazon-linux-latest/amzn2-ami-hvm-x86_64-gp2
+      - /cromwell/ami/amazon-linux2
   
   CromwellVersion:
     Type: String
@@ -180,7 +181,7 @@ Parameters:
     Type: String
     MinLength: '9'
     MaxLength: '18'
-    Default: 0.0.0.0/0
+    Default: 10.0.0.0/8
     AllowedPattern: "(\\d{1,3})\\.(\\d{1,3})\\.(\\d{1,3})\\.(\\d{1,3})/(\\d{1,2})"
     ConstraintDescription: must be a valid IP CIDR range of the form x.x.x.x/x.
   
@@ -191,7 +192,7 @@ Parameters:
     Type: String
     MinLength: '9'
     MaxLength: '18'
-    Default: 0.0.0.0/0
+    Default: 10.0.0.0/8
     AllowedPattern: "(\\d{1,3})\\.(\\d{1,3})\\.(\\d{1,3})\\.(\\d{1,3})/(\\d{1,2})"
     ConstraintDescription: must be a valid IP CIDR range of the form x.x.x.x/x.
 
@@ -382,6 +383,11 @@ Resources:
       - IpProtocol: tcp
         FromPort: 443
         ToPort: 443
+        CidrIp:
+          Ref: HTTPLocation
+      - IpProtocol: tcp
+        FromPort: 8000
+        ToPort: 8000
         CidrIp:
           Ref: HTTPLocation
 
@@ -912,7 +918,7 @@ Resources:
           /opt/aws/bin/cfn-signal -e $? --stack ${AWS::StackName} --resource EC2Instance --region ${AWS::Region}
       
       NetworkInterfaces:
-        - AssociatePublicIpAddress: true
+        - AssociatePublicIpAddress: false
           DeviceIndex: "0"
           GroupSet:
             - !Ref EC2SecurityGroup

--- a/src/templates/cromwell/cromwell-resources.template.yaml
+++ b/src/templates/cromwell/cromwell-resources.template.yaml
@@ -102,6 +102,7 @@ Parameters:
     - t3.large
     - t3.xlarge
     - t3.2xlarge
+    - m6i.4xlarge
     ConstraintDescription: "Must be 't3' instance type."
   
   VpcId:

--- a/src/templates/cromwell/cromwell-resources.template.yaml
+++ b/src/templates/cromwell/cromwell-resources.template.yaml
@@ -142,7 +142,7 @@ Parameters:
     Description: >-
       URL to a pre-built cromwell-*.jar file.  Example: https://mycicdserver.com/build/cromwell-XX-SNAP.jar.
       If this is specifed, CromwellVersion is ignored.
-    Default: "https://github.com/henriqueribeiro/cromwell/releases/download/78-AWS/cromwell-78-AWS.jar"
+    Default: "https://github.com/colingarvey/cromwell/releases/download/83.1-AWS-Roche/cromwell-83.1-AWS-Roche.jar"
   
   DBSubnetIDs:
     Type: List<AWS::EC2::Subnet::Id>


### PR DESCRIPTION
Updated Cromwell cfn template:
1.  Use Hardened image from RSC
2. Add 10.0.0.0/8 IP range to security groups of Cromwell
3. Add port 8000 inbound for Cromwell
4. Use Colin's patched jar by default
5.  Turn off Public IP assignment as it causes a security flag to be raised.